### PR TITLE
Fixed link to js in notebook

### DIFF
--- a/Detect_trucks_sentinel2_COVID19.ipynb
+++ b/Detect_trucks_sentinel2_COVID19.ipynb
@@ -9,7 +9,7 @@
     "Author: Henrik Fisser, 2020\n",
     "\n",
     "This script was developed and executed on the EOxHub-hosted JupyterLab and uses xcube for computations on data cubes retrieved from Sentinel Hub. If you do not have access to these resources you may execute the calculation as a Javascript on Sentinel-hub EO Browser. \n",
-    "You find the Javascript here: https://github.com/hfisser/Truck_Detection_Sentinel2_COVID19/blob/master/detect_trucks_sentinel2.js\n",
+    "You find the Javascript here: https://github.com/hfisser/Truck_Detection_Sentinel2_COVID19/blob/master/detect_trucks_sentinel2_COVID19.js\n",
     "\n",
     "What does this script do?\n",
     "----\n",


### PR DESCRIPTION
Hi,

I just noticed that the link to the js file was wrong, so here's the correct one.